### PR TITLE
Hotfix pour le déploiment automatique sur heroku

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
+//npm.pkg.github.com/:_authToken=${NPM_TOKEN}
+
 @tableaubits:registry=https://npm.pkg.github.com/

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
+# Comment this line before installing locally
 //npm.pkg.github.com/:_authToken=${NPM_TOKEN}
 
 @tableaubits:registry=https://npm.pkg.github.com/

--- a/.npmrc-ci
+++ b/.npmrc-ci
@@ -1,1 +1,3 @@
+//npm.pkg.github.com/:_authToken=${NPM_TOKEN}
+
 @tableaubits:registry=https://npm.pkg.github.com/

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"description": "MATBay! revamped back-end",
 	"main": "./dist/index.js",
 	"scripts": {
+		"heroku-prebuild": "mv .npmrc-ci .npmrc",
 		"start": "tsc && npx copyfiles -E -f src/REST/controllers/dashboard/*.ejs dist/REST/controllers/dashboard/ && node ./dist/index.js",
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},


### PR DESCRIPTION
## Description
Cette PR ajoute les méchanismes nécessaires à Kalimba pour pouvoir être déployé automatiquement sur Heroku, tout en permettant de se connecter manuellement localement

### :bug: Bugfix
* Sépéaration des informations dans 2 `.npmrc`:
  * le `.npmrc` de base permet à une personne qui clone le repo de se connecter manuellement et d'avoir accès au GPR qui contient Hang
  * `.npmrc-ci` contient en plus la ligne permettant à une configuration de CI/CD de se connecter automatiquement, à l'aide d'une variable d'environnement `NPM_TOKEN`. Dans le cas du déploiement automatique sur Heroku, c'est le script npm `heroku-prebuild` qui s'occupe de remplacer le `.npmrc` par `.npmrc-ci` (voir `package.json`)

## Checklist

- [x] Titre
- [x] Label
- [x] Catégorie