### PR TITLE
Self ping en REST pour maintenir le serveur sur heroku

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,11 @@
+# Secret for firebase service account key (mandatory)
+MATBAY_SERVICE_ACCOUNT_KEY=
+
+# Password for dashboard (optional, defaults to empty string)
+DASHBOARD_PASSWORD=
+
+# Deployment URL (if empty, will default to "http://localhost")
+DEPLOYMENT_URL=
+
+# Deployment port (optional, defaults to 3000)
+PORT=

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
 				"@types/ws": "^7.4.5",
 				"@typescript-eslint/eslint-plugin": "^4.23.0",
 				"@typescript-eslint/parser": "^4.23.0",
+				"axios": "^0.27.2",
 				"bufferutil": "^4.0.3",
 				"chelys": "^2.5.0",
 				"copyfiles": "^2.4.1",
@@ -847,9 +848,9 @@
 			}
 		},
 		"node_modules/async": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-			"integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+			"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
 		},
 		"node_modules/async-retry": {
 			"version": "1.3.1",
@@ -858,6 +859,20 @@
 			"optional": true,
 			"dependencies": {
 				"retry": "0.12.0"
+			}
+		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+		},
+		"node_modules/axios": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+			"integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+			"dependencies": {
+				"follow-redirects": "^1.14.9",
+				"form-data": "^4.0.0"
 			}
 		},
 		"node_modules/balanced-match": {
@@ -1048,6 +1063,17 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/compressible": {
 			"version": "2.0.18",
 			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -1193,6 +1219,14 @@
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
 		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -1285,11 +1319,11 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"node_modules/ejs": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
-			"integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.7.tgz",
+			"integrity": "sha512-BIar7R6abbUxDA3bfXrO4DSgwo8I+fB5/1zgujl3HLLjwd6+9iOnrT+t3grn2qbk9vOgBubXOFwX2m9axoFaGw==",
 			"dependencies": {
-				"jake": "^10.6.1"
+				"jake": "^10.8.5"
 			},
 			"bin": {
 				"ejs": "bin/cli.js"
@@ -1678,11 +1712,30 @@
 			}
 		},
 		"node_modules/filelist": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
-			"integrity": "sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.3.tgz",
+			"integrity": "sha512-LwjCsruLWQULGYKy7TX0OPtrL9kLpojOFKc5VCTxdFTV7w5zbsgqVKfnkKG7Qgjtq50gKfO56hJv88OfcGb70Q==",
 			"dependencies": {
-				"minimatch": "^3.0.4"
+				"minimatch": "^5.0.1"
+			}
+		},
+		"node_modules/filelist/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/filelist/node_modules/minimatch": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+			"integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/fill-range": {
@@ -1763,6 +1816,38 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
 			"integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA=="
+		},
+		"node_modules/follow-redirects": {
+			"version": "1.14.9",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+			"integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/form-data": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
 		},
 		"node_modules/forwarded": {
 			"version": "0.1.2",
@@ -2220,12 +2305,12 @@
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"node_modules/jake": {
-			"version": "10.8.2",
-			"resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
-			"integrity": "sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==",
+			"version": "10.8.5",
+			"resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
+			"integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
 			"dependencies": {
-				"async": "0.9.x",
-				"chalk": "^2.4.2",
+				"async": "^3.2.3",
+				"chalk": "^4.0.2",
 				"filelist": "^1.0.1",
 				"minimatch": "^3.0.4"
 			},
@@ -2233,20 +2318,7 @@
 				"jake": "bin/cli.js"
 			},
 			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/jake/node_modules/chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=4"
+				"node": ">=10"
 			}
 		},
 		"node_modules/jose": {
@@ -4486,9 +4558,9 @@
 			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
 		},
 		"async": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-			"integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+			"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
 		},
 		"async-retry": {
 			"version": "1.3.1",
@@ -4497,6 +4569,20 @@
 			"optional": true,
 			"requires": {
 				"retry": "0.12.0"
+			}
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+		},
+		"axios": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+			"integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+			"requires": {
+				"follow-redirects": "^1.14.9",
+				"form-data": "^4.0.0"
 			}
 		},
 		"balanced-match": {
@@ -4661,6 +4747,14 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
+		"combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"requires": {
+				"delayed-stream": "~1.0.0"
+			}
+		},
 		"compressible": {
 			"version": "2.0.18",
 			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -4775,6 +4869,11 @@
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
 		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+		},
 		"depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -4849,11 +4948,11 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"ejs": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
-			"integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.7.tgz",
+			"integrity": "sha512-BIar7R6abbUxDA3bfXrO4DSgwo8I+fB5/1zgujl3HLLjwd6+9iOnrT+t3grn2qbk9vOgBubXOFwX2m9axoFaGw==",
 			"requires": {
-				"jake": "^10.6.1"
+				"jake": "^10.8.5"
 			}
 		},
 		"emoji-regex": {
@@ -5167,11 +5266,29 @@
 			}
 		},
 		"filelist": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
-			"integrity": "sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.3.tgz",
+			"integrity": "sha512-LwjCsruLWQULGYKy7TX0OPtrL9kLpojOFKc5VCTxdFTV7w5zbsgqVKfnkKG7Qgjtq50gKfO56hJv88OfcGb70Q==",
 			"requires": {
-				"minimatch": "^3.0.4"
+				"minimatch": "^5.0.1"
+			},
+			"dependencies": {
+				"brace-expansion": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+					"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"minimatch": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+					"integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+					"requires": {
+						"brace-expansion": "^2.0.1"
+					}
+				}
 			}
 		},
 		"fill-range": {
@@ -5240,6 +5357,21 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
 			"integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA=="
+		},
+		"follow-redirects": {
+			"version": "1.14.9",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+			"integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+		},
+		"form-data": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			}
 		},
 		"forwarded": {
 			"version": "0.1.2",
@@ -5597,26 +5729,14 @@
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"jake": {
-			"version": "10.8.2",
-			"resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
-			"integrity": "sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==",
+			"version": "10.8.5",
+			"resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
+			"integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
 			"requires": {
-				"async": "0.9.x",
-				"chalk": "^2.4.2",
+				"async": "^3.2.3",
+				"chalk": "^4.0.2",
 				"filelist": "^1.0.1",
 				"minimatch": "^3.0.4"
-			},
-			"dependencies": {
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				}
 			}
 		},
 		"jose": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"@types/ws": "^7.4.5",
 		"@typescript-eslint/eslint-plugin": "^4.23.0",
 		"@typescript-eslint/parser": "^4.23.0",
+		"axios": "^0.27.2",
 		"bufferutil": "^4.0.3",
 		"chelys": "^2.5.0",
 		"copyfiles": "^2.4.1",

--- a/src/REST/controllers/keep-alive/keep-alive.ts
+++ b/src/REST/controllers/keep-alive/keep-alive.ts
@@ -1,0 +1,77 @@
+import { Router } from "express";
+
+export const KEEP_ALIVE_PATH = "keep-alive";
+const keepAliveController = Router();
+function* lyrics() {
+	while (true) {
+		yield "This was a triumph!";
+		yield "I'm making a note here:";
+		yield "Huge success!";
+		yield "It's hard to overstate";
+		yield "My satisfaction.";
+		yield "Aperture Science:";
+		yield "We do what we must";
+		yield "Because we can";
+		yield "For the good of all of us.";
+		yield "Except the ones who are dead.";
+		yield "But there's no sense crying";
+		yield "Over every mistake.";
+		yield "You just keep on trying";
+		yield "'Til you run out of cake.";
+		yield "And the science gets done.";
+		yield "And you make a neat gun";
+		yield "For the people who are";
+		yield "Still alive.";
+		yield "I'm not even angry...";
+		yield "I'm being so sincere right now.";
+		yield "Even though you broke my heart,";
+		yield "And killed me.";
+		yield "And tore me to pieces.";
+		yield "And threw every piece into a fire.";
+		yield "As they burned it hurt because";
+		yield "I was so happy for you!";
+		yield "Now, these points of data";
+		yield "Make a beautiful line.";
+		yield "And we're out of beta.";
+		yield "We're releasing on time!";
+		yield "So I'm GLaD I got burned!";
+		yield "Think of all the things we learned!";
+		yield "For the people who are";
+		yield "Still alive.";
+		yield "Go ahead and leave me...";
+		yield "I think I'd prefer to stay inside...";
+		yield "Maybe you'll find someone else";
+		yield "To help you.";
+		yield "Maybe Black Mesa?";
+		yield "That was a joke. Ha Ha. Fat Chance!";
+		yield "Anyway this cake is great!";
+		yield "It's so delicious and moist!";
+		yield "Look at me: still talking";
+		yield "When there's science to do!";
+		yield "When I look out there,";
+		yield "It makes me glad I'm not you.";
+		yield "I've experiments to run.";
+		yield "There is research to be done.";
+		yield "On the people who are";
+		yield "Still alive.";
+		yield "And believe me I am";
+		yield "Still alive.";
+		yield "I'm doing science and I'm";
+		yield "Still alive.";
+		yield "I feel fantastic and I'm";
+		yield "Still alive.";
+		yield "While you're dying I'll be";
+		yield "Still alive.";
+		yield "And when you're dead I will be";
+		yield "Still alive";
+		yield "Still alive.";
+		yield "Still alive.";
+	}
+}
+const lyricGenerator = lyrics();
+
+keepAliveController.get("/", async (_, res) => {
+	res.send(lyricGenerator.next().value);
+});
+
+export { keepAliveController };

--- a/src/REST/endpoint-creation.ts
+++ b/src/REST/endpoint-creation.ts
@@ -1,7 +1,11 @@
 import { Express } from "express";
 
 import { dashboardController } from "./controllers/dashboard/dashboard";
+import { KEEP_ALIVE_PATH, keepAliveController } from "./controllers/keep-alive/keep-alive";
 
 export function createEndpoints(app: Express): Express {
-	return app.use("/dashboard", dashboardController);
+	app.use("/dashboard", dashboardController);
+	app.use(`/${KEEP_ALIVE_PATH}`, keepAliveController);
+
+	return app;
 }

--- a/src/WebSocket/event-handler.ts
+++ b/src/WebSocket/event-handler.ts
@@ -9,6 +9,9 @@ import { inviteModule } from "./modules/invite";
 import { telemetry } from "./modules/telemetry";
 import { userModule } from "./modules/user";
 import { createMessage } from "./utility";
+import axios from "axios";
+import { PORT, SELF_URL } from "../constants";
+import { KEEP_ALIVE_PATH } from "../REST/controllers/keep-alive/keep-alive";
 
 // Telemetry HAS to be first!
 const modules: Module[] = [telemetry, userModule, constitutionModule, inviteModule];
@@ -107,6 +110,12 @@ function handleEvents(event: WebSocket.MessageEvent): void {
 		return;
 	}
 	if (message.event.startsWith("CLIENT")) {
+		if (message.event === EventType.CLIENT_ping) {
+			const url = `${SELF_URL}:${PORT}/${KEEP_ALIVE_PATH}`;
+			console.log(url);
+			axios.get(url)
+				.then((res) => console.log(res.data));
+		}
 		return;
 	}
 

--- a/src/WebSocket/firebase.ts
+++ b/src/WebSocket/firebase.ts
@@ -1,13 +1,7 @@
 import * as admin from "firebase-admin";
+import { ENCRYPTED_ADMIN_SAK } from "../constants";
 
-const encryptedAdminSAK = process.env["MATBAY_SERVICE_ACCOUNT_KEY"];
-
-if (encryptedAdminSAK == undefined) {
-	console.log("Unable to start server: firebase admin service acount key not found in ENV: MATBAY_SERVICE_ACCOUNT_KEY");
-	process.exit(-1);
-}
-
-const adminSAK = JSON.parse(Buffer.from(encryptedAdminSAK, "base64").toString());
+const adminSAK = JSON.parse(Buffer.from(ENCRYPTED_ADMIN_SAK, "base64").toString());
 
 admin.initializeApp({
 	credential: admin.credential.cert(adminSAK),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,12 @@
+const encryptedAdminSAK = process.env["MATBAY_SERVICE_ACCOUNT_KEY"];
+
+if (encryptedAdminSAK == undefined) {
+	console.log("Unable to start server: firebase admin service acount key not found in ENV: MATBAY_SERVICE_ACCOUNT_KEY");
+	process.exit(-1);
+}
+
+export const ENCRYPTED_ADMIN_SAK = encryptedAdminSAK;
+
+export const DASHBOARD_PASSWORD = process.env["DASHBOARD_PASSWORD"] || "";
+export const SELF_URL = process.env["SELF_URL"] || "http://localhost";
+export const PORT = process.env["PORT"] || 3000;


### PR DESCRIPTION
## Description
Cette PR ajoute une fonction qui fait en sorte de Kalimba se ping lui même via REST lorsqu'un ping WS se fait (`EventTypes.CLIENT_ping`). Ceci à pour but d'annuler la mise en veille automatique d'Heroku lorsqu'un utilisateur à une connexion WS active.

Le dernier méchanisme de défense d'Heroku ayant été contourné, je suspecte maintenant que plus rien n'empêche le site de rester indéfiniment allumé si un utilisateur garde sa connexion WS allumée constamment. Il va donc falloir faire attention.

### :rocket: Nouveauté
* Une variable d'environnement `DEPLOYMENT_URL` est nécessaire pour savoir quelle adresse pinger.
* Un nouveau controller et endpoint est disponible: `keep-alive`.

### :tada: Quality of life
* Le serveur se maintiens en vie sur heroku si une connexion WS est active
* un fichier `.env.template` pour savoir quelles variables d'environmment spécifier et quelles sont leurs valeurs par défaut.

### :hammer_and_wrench: Refactoring
* Les variables d'environnement sont maintenant récupérées, initialisées et vérifées dans un fichier central (`constants.ts`).

## Dépendance issues/pull request
reopens #10 

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie