### PR TITLE
Ajout de la requête de suppression d'une constitution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@typescript-eslint/eslint-plugin": "^4.23.0",
 				"@typescript-eslint/parser": "^4.23.0",
 				"bufferutil": "^4.0.3",
-				"chelys": "^2.5.0",
+				"chelys": "^2.6.0",
 				"copyfiles": "^2.4.1",
 				"cors": "^2.8.5",
 				"dotenv": "^10.0.0",
@@ -847,9 +847,9 @@
 			}
 		},
 		"node_modules/async": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-			"integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+			"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
 		},
 		"node_modules/async-retry": {
 			"version": "1.3.1",
@@ -1021,9 +1021,9 @@
 			}
 		},
 		"node_modules/chelys": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/chelys/-/chelys-2.5.0.tgz",
-			"integrity": "sha512-d1JQWkBx4Xv/5M1Zg2ua+flWgA94elzC77eFJ38h3VlNNoDS6EFtVn5Kx3pasVdXs+uvxTVpBIPYjU80JKzgHA=="
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/chelys/-/chelys-2.6.0.tgz",
+			"integrity": "sha512-xWI+mxoiGtFcmuUoQ4nolQBtMpAlXhLivLxsegmnOwF0mzGN+SpdlnkaigreOcE2IIKeYgLFGq4QCIt76hZ5VA=="
 		},
 		"node_modules/cliui": {
 			"version": "7.0.4",
@@ -1285,11 +1285,11 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"node_modules/ejs": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
-			"integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.7.tgz",
+			"integrity": "sha512-BIar7R6abbUxDA3bfXrO4DSgwo8I+fB5/1zgujl3HLLjwd6+9iOnrT+t3grn2qbk9vOgBubXOFwX2m9axoFaGw==",
 			"dependencies": {
-				"jake": "^10.6.1"
+				"jake": "^10.8.5"
 			},
 			"bin": {
 				"ejs": "bin/cli.js"
@@ -1678,11 +1678,30 @@
 			}
 		},
 		"node_modules/filelist": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
-			"integrity": "sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.3.tgz",
+			"integrity": "sha512-LwjCsruLWQULGYKy7TX0OPtrL9kLpojOFKc5VCTxdFTV7w5zbsgqVKfnkKG7Qgjtq50gKfO56hJv88OfcGb70Q==",
 			"dependencies": {
-				"minimatch": "^3.0.4"
+				"minimatch": "^5.0.1"
+			}
+		},
+		"node_modules/filelist/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/filelist/node_modules/minimatch": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+			"integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/fill-range": {
@@ -2220,12 +2239,12 @@
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"node_modules/jake": {
-			"version": "10.8.2",
-			"resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
-			"integrity": "sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==",
+			"version": "10.8.5",
+			"resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
+			"integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
 			"dependencies": {
-				"async": "0.9.x",
-				"chalk": "^2.4.2",
+				"async": "^3.2.3",
+				"chalk": "^4.0.2",
 				"filelist": "^1.0.1",
 				"minimatch": "^3.0.4"
 			},
@@ -2233,20 +2252,7 @@
 				"jake": "bin/cli.js"
 			},
 			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/jake/node_modules/chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=4"
+				"node": ">=10"
 			}
 		},
 		"node_modules/jose": {
@@ -4486,9 +4492,9 @@
 			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
 		},
 		"async": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-			"integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+			"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
 		},
 		"async-retry": {
 			"version": "1.3.1",
@@ -4634,9 +4640,9 @@
 			}
 		},
 		"chelys": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/chelys/-/chelys-2.5.0.tgz",
-			"integrity": "sha512-d1JQWkBx4Xv/5M1Zg2ua+flWgA94elzC77eFJ38h3VlNNoDS6EFtVn5Kx3pasVdXs+uvxTVpBIPYjU80JKzgHA=="
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/chelys/-/chelys-2.6.0.tgz",
+			"integrity": "sha512-xWI+mxoiGtFcmuUoQ4nolQBtMpAlXhLivLxsegmnOwF0mzGN+SpdlnkaigreOcE2IIKeYgLFGq4QCIt76hZ5VA=="
 		},
 		"cliui": {
 			"version": "7.0.4",
@@ -4849,11 +4855,11 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"ejs": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
-			"integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.7.tgz",
+			"integrity": "sha512-BIar7R6abbUxDA3bfXrO4DSgwo8I+fB5/1zgujl3HLLjwd6+9iOnrT+t3grn2qbk9vOgBubXOFwX2m9axoFaGw==",
 			"requires": {
-				"jake": "^10.6.1"
+				"jake": "^10.8.5"
 			}
 		},
 		"emoji-regex": {
@@ -5167,11 +5173,29 @@
 			}
 		},
 		"filelist": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
-			"integrity": "sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.3.tgz",
+			"integrity": "sha512-LwjCsruLWQULGYKy7TX0OPtrL9kLpojOFKc5VCTxdFTV7w5zbsgqVKfnkKG7Qgjtq50gKfO56hJv88OfcGb70Q==",
 			"requires": {
-				"minimatch": "^3.0.4"
+				"minimatch": "^5.0.1"
+			},
+			"dependencies": {
+				"brace-expansion": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+					"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"minimatch": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+					"integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+					"requires": {
+						"brace-expansion": "^2.0.1"
+					}
+				}
 			}
 		},
 		"fill-range": {
@@ -5597,26 +5621,14 @@
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"jake": {
-			"version": "10.8.2",
-			"resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
-			"integrity": "sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==",
+			"version": "10.8.5",
+			"resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
+			"integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
 			"requires": {
-				"async": "0.9.x",
-				"chalk": "^2.4.2",
+				"async": "^3.2.3",
+				"chalk": "^4.0.2",
 				"filelist": "^1.0.1",
 				"minimatch": "^3.0.4"
-			},
-			"dependencies": {
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				}
 			}
 		},
 		"jose": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@typescript-eslint/eslint-plugin": "^4.23.0",
 		"@typescript-eslint/parser": "^4.23.0",
 		"bufferutil": "^4.0.3",
-		"chelys": "^2.5.0",
+		"chelys": "^2.6.0",
 		"copyfiles": "^2.4.1",
 		"cors": "^2.8.5",
 		"dotenv": "^10.0.0",

--- a/src/WebSocket/modules/constitution-manager.ts
+++ b/src/WebSocket/modules/constitution-manager.ts
@@ -164,7 +164,8 @@ class ConstitutionManagerModule extends Module {
 
 		if (constitution.module.data.users[OWNER_INDEX] !== client.uid) return;		// only the owner can delete a constitution
 
-		firestore.doc(`${FS_CONSTITUTIONS_PATH}/${constitution.module.data.id}`).delete();
+		const doc = firestore.doc(`${FS_CONSTITUTIONS_PATH}/${constitution.module.data.id}`);
+		firestore.recursiveDelete(doc);
 	}
 
 	private async join(message: Message<unknown>, client: Client): Promise<void> {

--- a/src/WebSocket/modules/constitution-manager.ts
+++ b/src/WebSocket/modules/constitution-manager.ts
@@ -1,4 +1,4 @@
-import { Constitution, ConstitutionType, CstReqCreate, CstReqGet, CstReqJoin, CstResJoin, CstReqState, CstReqUnsubscribe, CstResUpdate, EventType, extractMessageData, KGradeSummary, Message, OWNER_INDEX, ResponseStatus, Role, CstReqNameURL } from "chelys";
+import { Constitution, ConstitutionType, CstReqCreate, CstReqGet, CstReqJoin, CstResJoin, CstReqState, CstReqUnsubscribe, CstResUpdate, EventType, extractMessageData, KGradeSummary, Message, OWNER_INDEX, ResponseStatus, Role, CstReqNameURL, CstReqDelete, CstResDelete } from "chelys";
 import { clamp, isNil } from "lodash";
 import { Client } from "../../Types/client";
 import { createID, firestore, firestoreTypes } from "../firebase";
@@ -34,6 +34,7 @@ class ConstitutionManagerModule extends Module {
 		this.moduleMap.set(EventType.CST_name_url, this.nameURL);
 		this.moduleMap.set(EventType.CST_state, this.state);
 		this.moduleMap.set(EventType.CST_unsubscribe, this.unsubscribe);
+		this.moduleMap.set(EventType.CST_delete, this.delete);
 
 		firestore.collection(FS_CONSTITUTIONS_PATH).onSnapshot((collection) => {
 			for (const change of collection.docChanges()) {
@@ -57,7 +58,12 @@ class ConstitutionManagerModule extends Module {
 
 					case "removed":
 						// @TODO(Ithyx): Send deletion event (or something idk)
+						this.constitutions.get(newConstitutionData.id)?.listeners.forEach((listener) => {
+							listener.socket.send((createMessage<CstResDelete>(EventType.CST_delete, {id: newConstitutionData.id})));
+						});
+
 						this.constitutions.delete(newConstitutionData.id);
+
 						break;
 
 					case "modified": {
@@ -148,6 +154,17 @@ class ConstitutionManagerModule extends Module {
 
 		firestore.doc(`${FS_CONSTITUTIONS_PATH}/${constitution.id}/favs/${client.uid}`).create({ uid: client.uid, favs: [] });
 		telemetry.write(false);
+	}
+
+	private async delete(message: Message<unknown>, client: Client): Promise<void> {
+		const constitutionID = extractMessageData<CstReqDelete>(message).id;
+		const constitution = this.constitutions.get(constitutionID);
+
+		if (isNil(constitutionID) || isNil(constitution)) return;
+
+		if (constitution.module.data.users[OWNER_INDEX] !== client.uid) return;		// only the owner can delete a constitution
+
+		firestore.doc(`${FS_CONSTITUTIONS_PATH}/${constitution.module.data.id}`).delete();
 	}
 
 	private async join(message: Message<unknown>, client: Client): Promise<void> {


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :rocket: Nouveauté
* Ajout de la requête `CST_delete`. Après la suppression du document dans la DB Firebase, Kalimba envoie un event à tous les utilisateurs écoutant la constitution supprimée.
* Passage à Chelys 2.6.0.

## Dépendance issues/pull request
<!-- * #{Numéro issue } -->

Équivalent Yagta : https://github.com/TableauBits/Yatga/pull/58

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie