### PR TITLE
Revert self ping et endpoint REST pour les informations utilisateur

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -3,9 +3,3 @@ MATBAY_SERVICE_ACCOUNT_KEY=
 
 # Password for dashboard (optional, defaults to empty string)
 DASHBOARD_PASSWORD=
-
-# Deployment URL (if empty, will default to "http://localhost")
-DEPLOYMENT_URL=
-
-# Deployment port (optional, defaults to 3000)
-PORT=

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.0.0",
 			"license": "ISC",
 			"dependencies": {
+				"@angular/language-server": "^14.0.1",
 				"@types/cors": "^2.8.10",
 				"@types/ejs": "^3.0.7",
 				"@types/express": "^4.17.11",
@@ -16,7 +17,6 @@
 				"@types/ws": "^7.4.5",
 				"@typescript-eslint/eslint-plugin": "^4.23.0",
 				"@typescript-eslint/parser": "^4.23.0",
-				"axios": "^0.27.2",
 				"bufferutil": "^4.0.3",
 				"chelys": "^2.6.0",
 				"copyfiles": "^2.4.1",
@@ -30,6 +30,31 @@
 				"typescript": "^4.2.4",
 				"utf-8-validate": "^5.0.5",
 				"ws": "^7.5.1"
+			}
+		},
+		"node_modules/@angular/language-server": {
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/@angular/language-server/-/language-server-14.0.1.tgz",
+			"integrity": "sha512-7+jB+Sz+PpcprNMABty8q3EymjLGLBw5ym83wWtRszD7Rwhng2SL5TA6GV0h/54Y4Nz6Eoaw0mblYLa1w9Wa3Q==",
+			"dependencies": {
+				"@angular/language-service": "14.0.0",
+				"vscode-jsonrpc": "6.0.0",
+				"vscode-languageserver": "7.0.0",
+				"vscode-uri": "3.0.3"
+			},
+			"bin": {
+				"ngserver": "bin/ngserver"
+			},
+			"engines": {
+				"node": "^14.15.0 || >=16.10.0"
+			}
+		},
+		"node_modules/@angular/language-service": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-14.0.0.tgz",
+			"integrity": "sha512-05P+3IJ+pT9WQdUcXVM4NGY1a8V1bGKRVEE6BFFPYG+ElrM2aR7e0j997zAPIwPLWT1Z8/oC1wJ3MCBBTbECVQ==",
+			"engines": {
+				"node": "^14.15.0 || >=16.10.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -861,20 +886,6 @@
 				"retry": "0.12.0"
 			}
 		},
-		"node_modules/asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-		},
-		"node_modules/axios": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-			"integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-			"dependencies": {
-				"follow-redirects": "^1.14.9",
-				"form-data": "^4.0.0"
-			}
-		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -957,6 +968,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.3.tgz",
 			"integrity": "sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==",
+			"hasInstallScript": true,
 			"dependencies": {
 				"node-gyp-build": "^4.2.0"
 			}
@@ -1062,17 +1074,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-		},
-		"node_modules/combined-stream": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"dependencies": {
-				"delayed-stream": "~1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
 		},
 		"node_modules/compressible": {
 			"version": "2.0.18",
@@ -1219,14 +1220,6 @@
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
 		},
-		"node_modules/delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -1241,14 +1234,14 @@
 			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
 		},
 		"node_modules/dicer": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
-			"integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.1.tgz",
+			"integrity": "sha512-ObioMtXnmjYs3aRtpIJt9rgQSPCIhKVkFPip+E9GUDyWl8N435znUxK/JfNwGZJ2wnn5JKQ7Ly3vOK5Q5dylGA==",
 			"dependencies": {
-				"streamsearch": "0.1.2"
+				"streamsearch": "^1.1.0"
 			},
 			"engines": {
-				"node": ">=4.5.0"
+				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/dir-glob": {
@@ -1816,38 +1809,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
 			"integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA=="
-		},
-		"node_modules/follow-redirects": {
-			"version": "1.14.9",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-			"integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/RubenVerborgh"
-				}
-			],
-			"engines": {
-				"node": ">=4.0"
-			},
-			"peerDependenciesMeta": {
-				"debug": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/form-data": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
 		},
 		"node_modules/forwarded": {
 			"version": "0.1.2",
@@ -2923,9 +2884,10 @@
 			}
 		},
 		"node_modules/protobufjs": {
-			"version": "6.11.2",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-			"integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+			"version": "6.11.3",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+			"integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+			"hasInstallScript": true,
 			"optional": true,
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.2",
@@ -3315,11 +3277,11 @@
 			"optional": true
 		},
 		"node_modules/streamsearch": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-			"integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
 			"engines": {
-				"node": ">=0.8.0"
+				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/string_decoder": {
@@ -3608,6 +3570,7 @@
 			"version": "5.0.5",
 			"resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.5.tgz",
 			"integrity": "sha512-+pnxRYsS/axEpkrrEpzYfNZGXp0IjC/9RIxwM5gntY4Koi8SHmUGSfxfWqxZdRxrtaoVstuOzUp/rbs3JSPELQ==",
+			"hasInstallScript": true,
 			"dependencies": {
 				"node-gyp-build": "^4.2.0"
 			}
@@ -3646,6 +3609,44 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
+		},
+		"node_modules/vscode-jsonrpc": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+			"integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+			"engines": {
+				"node": ">=8.0.0 || >=10.0.0"
+			}
+		},
+		"node_modules/vscode-languageserver": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
+			"integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
+			"dependencies": {
+				"vscode-languageserver-protocol": "3.16.0"
+			},
+			"bin": {
+				"installServerIntoExtension": "bin/installServerIntoExtension"
+			}
+		},
+		"node_modules/vscode-languageserver-protocol": {
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+			"integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+			"dependencies": {
+				"vscode-jsonrpc": "6.0.0",
+				"vscode-languageserver-types": "3.16.0"
+			}
+		},
+		"node_modules/vscode-languageserver-types": {
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+			"integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+		},
+		"node_modules/vscode-uri": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.3.tgz",
+			"integrity": "sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA=="
 		},
 		"node_modules/webidl-conversions": {
 			"version": "3.0.1",
@@ -3837,6 +3838,22 @@
 		}
 	},
 	"dependencies": {
+		"@angular/language-server": {
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/@angular/language-server/-/language-server-14.0.1.tgz",
+			"integrity": "sha512-7+jB+Sz+PpcprNMABty8q3EymjLGLBw5ym83wWtRszD7Rwhng2SL5TA6GV0h/54Y4Nz6Eoaw0mblYLa1w9Wa3Q==",
+			"requires": {
+				"@angular/language-service": "14.0.0",
+				"vscode-jsonrpc": "6.0.0",
+				"vscode-languageserver": "7.0.0",
+				"vscode-uri": "3.0.3"
+			}
+		},
+		"@angular/language-service": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-14.0.0.tgz",
+			"integrity": "sha512-05P+3IJ+pT9WQdUcXVM4NGY1a8V1bGKRVEE6BFFPYG+ElrM2aR7e0j997zAPIwPLWT1Z8/oC1wJ3MCBBTbECVQ=="
+		},
 		"@babel/code-frame": {
 			"version": "7.12.11",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -4571,20 +4588,6 @@
 				"retry": "0.12.0"
 			}
 		},
-		"asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-		},
-		"axios": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-			"integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-			"requires": {
-				"follow-redirects": "^1.14.9",
-				"form-data": "^4.0.0"
-			}
-		},
 		"balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4747,14 +4750,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
-		"combined-stream": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"requires": {
-				"delayed-stream": "~1.0.0"
-			}
-		},
 		"compressible": {
 			"version": "2.0.18",
 			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -4869,11 +4864,6 @@
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
 		},
-		"delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-		},
 		"depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -4885,11 +4875,11 @@
 			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
 		},
 		"dicer": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
-			"integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.1.tgz",
+			"integrity": "sha512-ObioMtXnmjYs3aRtpIJt9rgQSPCIhKVkFPip+E9GUDyWl8N435znUxK/JfNwGZJ2wnn5JKQ7Ly3vOK5Q5dylGA==",
 			"requires": {
-				"streamsearch": "0.1.2"
+				"streamsearch": "^1.1.0"
 			}
 		},
 		"dir-glob": {
@@ -5357,21 +5347,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
 			"integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA=="
-		},
-		"follow-redirects": {
-			"version": "1.14.9",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-			"integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
-		},
-		"form-data": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
-			}
 		},
 		"forwarded": {
 			"version": "0.1.2",
@@ -6221,9 +6196,9 @@
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
 		},
 		"protobufjs": {
-			"version": "6.11.2",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-			"integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+			"version": "6.11.3",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+			"integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
 			"optional": true,
 			"requires": {
 				"@protobufjs/aspromise": "^1.1.2",
@@ -6539,9 +6514,9 @@
 			"optional": true
 		},
 		"streamsearch": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-			"integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
 		},
 		"string_decoder": {
 			"version": "1.3.0",
@@ -6812,6 +6787,38 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
 			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+		},
+		"vscode-jsonrpc": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+			"integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
+		},
+		"vscode-languageserver": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
+			"integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
+			"requires": {
+				"vscode-languageserver-protocol": "3.16.0"
+			}
+		},
+		"vscode-languageserver-protocol": {
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+			"integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+			"requires": {
+				"vscode-jsonrpc": "6.0.0",
+				"vscode-languageserver-types": "3.16.0"
+			}
+		},
+		"vscode-languageserver-types": {
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+			"integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+		},
+		"vscode-uri": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.3.tgz",
+			"integrity": "sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA=="
 		},
 		"webidl-conversions": {
 			"version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 	"author": "TableauBits",
 	"license": "ISC",
 	"dependencies": {
+		"@angular/language-server": "^14.0.1",
 		"@types/cors": "^2.8.10",
 		"@types/ejs": "^3.0.7",
 		"@types/express": "^4.17.11",
@@ -17,7 +18,6 @@
 		"@types/ws": "^7.4.5",
 		"@typescript-eslint/eslint-plugin": "^4.23.0",
 		"@typescript-eslint/parser": "^4.23.0",
-		"axios": "^0.27.2",
 		"bufferutil": "^4.0.3",
 		"chelys": "^2.6.0",
 		"copyfiles": "^2.4.1",

--- a/src/REST/controllers/user-info/user-info.ts
+++ b/src/REST/controllers/user-info/user-info.ts
@@ -1,0 +1,21 @@
+import { Router } from "express";
+import { userModule } from '../../../WebSocket/modules/user'
+
+export const USER_INFO_PATH = "user-info";
+
+const UserInfoController = Router();
+
+const USER_UID = 0;
+const USER_DISPLAY_NAME = 1
+
+UserInfoController.get("/", async (_, res) => {
+  const uidToName: Record<string, string> = {};
+
+  Array.from(userModule.users.entries()).forEach((entry) => {
+    uidToName[entry[USER_UID]] = entry[USER_DISPLAY_NAME].data.displayName;
+  })
+  
+  res.send(JSON.stringify(uidToName));
+})
+
+export {UserInfoController}

--- a/src/REST/endpoint-creation.ts
+++ b/src/REST/endpoint-creation.ts
@@ -2,10 +2,12 @@ import { Express } from "express";
 
 import { dashboardController } from "./controllers/dashboard/dashboard";
 import { KEEP_ALIVE_PATH, keepAliveController } from "./controllers/keep-alive/keep-alive";
+import { USER_INFO_PATH, UserInfoController } from "./controllers/user-info/user-info";
 
 export function createEndpoints(app: Express): Express {
 	app.use("/dashboard", dashboardController);
 	app.use(`/${KEEP_ALIVE_PATH}`, keepAliveController);
+	app.use(`/${USER_INFO_PATH}`, UserInfoController);
 
 	return app;
 }

--- a/src/WebSocket/event-handler.ts
+++ b/src/WebSocket/event-handler.ts
@@ -9,9 +9,6 @@ import { inviteModule } from "./modules/invite";
 import { telemetry } from "./modules/telemetry";
 import { userModule } from "./modules/user";
 import { createMessage } from "./utility";
-import axios from "axios";
-import { PORT, SELF_URL } from "../constants";
-import { KEEP_ALIVE_PATH } from "../REST/controllers/keep-alive/keep-alive";
 
 // Telemetry HAS to be first!
 const modules: Module[] = [telemetry, userModule, constitutionModule, inviteModule];
@@ -110,12 +107,6 @@ function handleEvents(event: WebSocket.MessageEvent): void {
 		return;
 	}
 	if (message.event.startsWith("CLIENT")) {
-		if (message.event === EventType.CLIENT_ping) {
-			const url = `${SELF_URL}:${PORT}/${KEEP_ALIVE_PATH}`;
-			console.log(url);
-			axios.get(url)
-				.then((res) => console.log(res.data));
-		}
 		return;
 	}
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,5 +8,3 @@ if (encryptedAdminSAK == undefined) {
 export const ENCRYPTED_ADMIN_SAK = encryptedAdminSAK;
 
 export const DASHBOARD_PASSWORD = process.env["DASHBOARD_PASSWORD"] || "";
-export const SELF_URL = process.env["SELF_URL"] || "http://localhost";
-export const PORT = process.env["PORT"] || 3000;


### PR DESCRIPTION
## Description
Cette PR a pour but de revert la tentative de self ping, mais garde l'endpoitn keep alive pour que les clients puissent l'appeller.
De plus, un nouvel endpoint pour récupérer le maping des UID -> username à été créé (sera utilisé principalement dans Mellotron)

### :rocket: Nouveauté
* Endpoint `user-info` pour récupérer le mapping entre UID et usernames.

### :hammer_and_wrench: Refactoring
* Supression du callback de self-ping lors d'un CLIENT_ping

## Dépendance issues/pull request
Closes #33 

## Checklist

- [x] Titre
- [x] Label
- [x] Catégorie