### PR TITLE
Correction de la requête HTTP `keep-alive`

### DIFF
--- a/src/REST/controllers/keep-alive/keep-alive.ts
+++ b/src/REST/controllers/keep-alive/keep-alive.ts
@@ -71,7 +71,7 @@ function* lyrics() {
 const lyricGenerator = lyrics();
 
 keepAliveController.get("/", async (_, res) => {
-	res.send(lyricGenerator.next().value);
+	res.send(JSON.stringify(lyricGenerator.next().value));
 });
 
 export { keepAliveController };

--- a/src/REST/controllers/user-info/user-info.ts
+++ b/src/REST/controllers/user-info/user-info.ts
@@ -1,21 +1,21 @@
 import { Router } from "express";
-import { userModule } from '../../../WebSocket/modules/user'
+import { userModule } from "../../../WebSocket/modules/user";
 
 export const USER_INFO_PATH = "user-info";
 
 const UserInfoController = Router();
 
 const USER_UID = 0;
-const USER_DISPLAY_NAME = 1
+const USER_DISPLAY_NAME = 1;
 
 UserInfoController.get("/", async (_, res) => {
-  const uidToName: Record<string, string> = {};
+	const uidToName: Record<string, string> = {};
 
-  Array.from(userModule.users.entries()).forEach((entry) => {
-    uidToName[entry[USER_UID]] = entry[USER_DISPLAY_NAME].data.displayName;
-  })
+	Array.from(userModule.users.entries()).forEach((entry) => {
+		uidToName[entry[USER_UID]] = entry[USER_DISPLAY_NAME].data.displayName;
+	});
   
-  res.send(JSON.stringify(uidToName));
-})
+	res.send(JSON.stringify(uidToName));
+});
 
-export {UserInfoController}
+export { UserInfoController };

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,7 @@ import { setupWS } from "./WebSocket/event-handler";
 
 // create HTTP server
 const port = process.env["PORT"] || 3000;
-const server = createEndpoints(express())
-	.use(cors())
+const server = createEndpoints(express().use(cors()))
 	.listen(port, () => console.log(`server listening on ${port}`));
 
 // create WS server


### PR DESCRIPTION
Co-authored-by: Mathis Lamidey <Ithyx@users.noreply.github.com>

## Description
<!-- Résumé des changements. -->

### :bug: Bugfix
* Application du lint pour le controller de `user-info`.
* Correction du format de la réponse de la requête HTTP `keep-alive`.
* Utilisation du mécanisme CORS.

## Dépendance issues/pull request
<!-- * #{Numéro issue } -->

* S'applique à https://github.com/TableauBits/Yatga/pull/62

## Checklist

- [x] Titre
- [x] Label
- [x] Catégorie