### PR TITLE
Refactorisation des votes pour permettre de voter pendant l'ajout de chansons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@typescript-eslint/eslint-plugin": "^4.23.0",
 				"@typescript-eslint/parser": "^4.23.0",
 				"bufferutil": "^4.0.3",
-				"chelys": "^2.8.0",
+				"chelys": "^2.8.1",
 				"copyfiles": "^2.4.1",
 				"cors": "^2.8.5",
 				"dotenv": "^10.0.0",
@@ -1048,9 +1048,9 @@
 			}
 		},
 		"node_modules/chelys": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/chelys/-/chelys-2.8.0.tgz",
-			"integrity": "sha512-aTGLMojQEexa15ZN84ZDYPNmA+NVbUi/DNgNHmdaIcy9L691dZ8tzn/ZOHEyagIVAjlO46xAKURkW0Yt2eOWNA=="
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/chelys/-/chelys-2.8.1.tgz",
+			"integrity": "sha512-XqXf5pHFVIAwK46NRAhlz/2ayMG7O2PR2EUarrn5REY/nosQmeeossIdfOKMz6SLg0b/ycI5MTulIBneg4BiBA=="
 		},
 		"node_modules/cliui": {
 			"version": "7.0.4",
@@ -4583,9 +4583,9 @@
 			}
 		},
 		"chelys": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/chelys/-/chelys-2.8.0.tgz",
-			"integrity": "sha512-aTGLMojQEexa15ZN84ZDYPNmA+NVbUi/DNgNHmdaIcy9L691dZ8tzn/ZOHEyagIVAjlO46xAKURkW0Yt2eOWNA=="
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/chelys/-/chelys-2.8.1.tgz",
+			"integrity": "sha512-XqXf5pHFVIAwK46NRAhlz/2ayMG7O2PR2EUarrn5REY/nosQmeeossIdfOKMz6SLg0b/ycI5MTulIBneg4BiBA=="
 		},
 		"cliui": {
 			"version": "7.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@typescript-eslint/eslint-plugin": "^4.23.0",
 				"@typescript-eslint/parser": "^4.23.0",
 				"bufferutil": "^4.0.3",
-				"chelys": "^2.7.8",
+				"chelys": "^2.8.0",
 				"copyfiles": "^2.4.1",
 				"cors": "^2.8.5",
 				"dotenv": "^10.0.0",
@@ -1048,9 +1048,9 @@
 			}
 		},
 		"node_modules/chelys": {
-			"version": "2.7.8",
-			"resolved": "https://registry.npmjs.org/chelys/-/chelys-2.7.8.tgz",
-			"integrity": "sha512-0i2vv5WbAxV2y+Cpeb5DaimqBm+z//K5VK2+idX7Ti+P29ZUNB3fqas0wMy4klGYZvOl9/lug+VGMcD5U7Fpkg=="
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/chelys/-/chelys-2.8.0.tgz",
+			"integrity": "sha512-aTGLMojQEexa15ZN84ZDYPNmA+NVbUi/DNgNHmdaIcy9L691dZ8tzn/ZOHEyagIVAjlO46xAKURkW0Yt2eOWNA=="
 		},
 		"node_modules/cliui": {
 			"version": "7.0.4",
@@ -4583,9 +4583,9 @@
 			}
 		},
 		"chelys": {
-			"version": "2.7.8",
-			"resolved": "https://registry.npmjs.org/chelys/-/chelys-2.7.8.tgz",
-			"integrity": "sha512-0i2vv5WbAxV2y+Cpeb5DaimqBm+z//K5VK2+idX7Ti+P29ZUNB3fqas0wMy4klGYZvOl9/lug+VGMcD5U7Fpkg=="
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/chelys/-/chelys-2.8.0.tgz",
+			"integrity": "sha512-aTGLMojQEexa15ZN84ZDYPNmA+NVbUi/DNgNHmdaIcy9L691dZ8tzn/ZOHEyagIVAjlO46xAKURkW0Yt2eOWNA=="
 		},
 		"cliui": {
 			"version": "7.0.4",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"@typescript-eslint/eslint-plugin": "^4.23.0",
 		"@typescript-eslint/parser": "^4.23.0",
 		"bufferutil": "^4.0.3",
-		"chelys": "^2.7.8",
+		"chelys": "^2.8.0",
 		"copyfiles": "^2.4.1",
 		"cors": "^2.8.5",
 		"dotenv": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"@typescript-eslint/eslint-plugin": "^4.23.0",
 		"@typescript-eslint/parser": "^4.23.0",
 		"bufferutil": "^4.0.3",
-		"chelys": "^2.8.0",
+		"chelys": "^2.8.1",
 		"copyfiles": "^2.4.1",
 		"cors": "^2.8.5",
 		"dotenv": "^10.0.0",

--- a/src/Types/song-data.ts
+++ b/src/Types/song-data.ts
@@ -1,6 +1,6 @@
 import { Constitution, Song } from "chelys";
 
-export interface VoteData {
+export interface SongData {
 	songs: Map<number, Song>;
 	constitution: Constitution;
 }

--- a/src/WebSocket/modules/constitution.ts
+++ b/src/WebSocket/modules/constitution.ts
@@ -2,13 +2,11 @@ import { Constitution, Message } from "chelys";
 import { SubModule } from "../module";
 import { Client } from "../../Types/client";
 import { SongModule } from "./song";
-import { FavoriteModule } from "./favorite";
 
 export class ConstitutionModule {
 	private submodules: SubModule<Constitution>[] = [];
 	constructor(public data: Constitution) {
 		this.submodules.push(new SongModule(data));
-		this.submodules.push(new FavoriteModule(data));
 	}
 
 	public updateData(data: Constitution): void {

--- a/src/WebSocket/modules/favorite.ts
+++ b/src/WebSocket/modules/favorite.ts
@@ -1,12 +1,13 @@
-import { areResultsPublic, canModifyVotes, Constitution, createMessage, CstFavReqAdd, CstFavResUpdate, EventType, extractMessageData, FAVORITES_MAX_LENGTH, Message, UserFavorites } from "chelys";
+import { areResultsPublic, canModifyVotes, Constitution, createMessage, EventType, extractMessageData, FAVORITES_MAX_LENGTH, FavReqAdd, FavResUpdate, Message, Song, UserFavorites } from "chelys";
 import { firestore, firestoreTypes } from "../firebase";
 import { Client } from "../../Types/client";
 import { SubModule } from "../module";
-import { FS_CONSTITUTIONS_PATH } from "../utility";
+import { FS_CONSTITUTIONS_PATH, removeFromArray } from "../utility";
 import { telemetry } from "./telemetry";
 import { isNil } from "lodash";
+import { SongData } from "../../Types/song-data";
 
-export class FavoriteModule extends SubModule<Constitution> {
+export class FavoriteModule extends SubModule<SongData> {
 	public prefix = "FAV";
 
 	private path = "";
@@ -14,20 +15,20 @@ export class FavoriteModule extends SubModule<Constitution> {
 
 	private listeners: Set<Client> = new Set();
 
-	constructor(private constitution: Constitution) {
+	constructor(private constitution: Constitution, private songList: Map<number, Song>) {
 		super();
 
-		this.moduleMap.set(EventType.CST_FAV_add, this.add);
-		this.moduleMap.set(EventType.CST_FAV_remove, this.remove);
-		this.moduleMap.set(EventType.CST_FAV_get, this.get);
-		this.moduleMap.set(EventType.CST_FAV_unsubscribe, this.unsubscribe);
+		this.moduleMap.set(EventType.CST_SONG_FAV_add, this.add);
+		this.moduleMap.set(EventType.CST_SONG_FAV_remove, this.remove);
+		this.moduleMap.set(EventType.CST_SONG_FAV_get, this.get);
+		this.moduleMap.set(EventType.CST_SONG_FAV_unsubscribe, this.unsubscribe);
 
 		this.path = `${FS_CONSTITUTIONS_PATH}/${constitution.id}/favs`;
 
 		firestore.collection(this.path).onSnapshot((collection) => {
 			for (const change of collection.docChanges()) {
 				const newFavData = change.doc.data() as UserFavorites;
-				const updateMessage = createMessage<CstFavResUpdate>(EventType.CST_FAV_update, { userFavorites: newFavData });
+				const updateMessage = createMessage<FavResUpdate>(EventType.CST_FAV_update, { userFavorites: newFavData });
 				switch (change.type) {
 					case "added":
 						this.favorites.set(newFavData.uid, newFavData);
@@ -69,10 +70,10 @@ export class FavoriteModule extends SubModule<Constitution> {
 		this.listeners.delete(client);
 	}
 
-	public updateData(data: Constitution): void {
-		if (this.constitution.state !== data.state) {
+	public updateData(data: SongData): void {
+		if (this.constitution.state !== data.constitution.state) {
 			this.favorites.forEach((favorite) => {
-				const updateMessage = createMessage<CstFavResUpdate>(EventType.CST_FAV_update, { userFavorites: favorite });
+				const updateMessage = createMessage<FavResUpdate>(EventType.CST_FAV_update, { userFavorites: favorite });
 				this.listeners.forEach((listener) => {
 					if (areResultsPublic(this.constitution) || listener.uid !== favorite.uid) {
 						listener.socket.send(updateMessage);
@@ -81,7 +82,14 @@ export class FavoriteModule extends SubModule<Constitution> {
 				});
 			});
 		}
-		this.constitution = data;
+		this.constitution = data.constitution;
+		this.songList = data.songs;
+	}
+
+	public async deleteFavorites(songID: number): Promise<void> {
+		for (const user of this.constitution.users) {
+			firestore.collection(this.path).doc(user).update({ favs: firestoreTypes.FieldValue.arrayRemove(songID) });
+		}
 	}
 
 	private async add(message: Message<unknown>, client: Client): Promise<void> {
@@ -90,12 +98,12 @@ export class FavoriteModule extends SubModule<Constitution> {
 		if (isNil(favorites)) return;
 		if (favorites.favs.length >= FAVORITES_MAX_LENGTH) return;
 
-		const newFav = extractMessageData<CstFavReqAdd>(message);
+		const newFav = extractMessageData<FavReqAdd>(message);
 		firestore.collection(this.path).doc(client.uid).update({ favs: firestoreTypes.FieldValue.arrayUnion(newFav.songId) });
 	}
 
 	private async remove(message: Message<unknown>, client: Client): Promise<void> {
-		const favToRemove = extractMessageData<CstFavReqAdd>(message);
+		const favToRemove = extractMessageData<FavReqAdd>(message);
 		firestore.collection(this.path).doc(client.uid).update({ favs: firestoreTypes.FieldValue.arrayRemove(favToRemove.songId) });
 	}
 
@@ -103,7 +111,7 @@ export class FavoriteModule extends SubModule<Constitution> {
 		this.listeners.add(client);
 
 		this.favorites.forEach((favorite) => {
-			const updateMessage = createMessage<CstFavResUpdate>(EventType.CST_FAV_update, { userFavorites: favorite });
+			const updateMessage = createMessage<FavResUpdate>(EventType.CST_FAV_update, { userFavorites: favorite });
 			if (areResultsPublic(this.constitution) || client.uid === favorite.uid) {
 				client.socket.send(updateMessage);
 				telemetry.read();

--- a/src/WebSocket/modules/favorite.ts
+++ b/src/WebSocket/modules/favorite.ts
@@ -28,7 +28,7 @@ export class FavoriteModule extends SubModule<SongData> {
 		firestore.collection(this.path).onSnapshot((collection) => {
 			for (const change of collection.docChanges()) {
 				const newFavData = change.doc.data() as UserFavorites;
-				const updateMessage = createMessage<FavResUpdate>(EventType.CST_FAV_update, { userFavorites: newFavData });
+				const updateMessage = createMessage<FavResUpdate>(EventType.CST_SONG_FAV_update, { userFavorites: newFavData });
 				switch (change.type) {
 					case "added":
 						this.favorites.set(newFavData.uid, newFavData);
@@ -73,7 +73,7 @@ export class FavoriteModule extends SubModule<SongData> {
 	public updateData(data: SongData): void {
 		if (this.constitution.state !== data.constitution.state) {
 			this.favorites.forEach((favorite) => {
-				const updateMessage = createMessage<FavResUpdate>(EventType.CST_FAV_update, { userFavorites: favorite });
+				const updateMessage = createMessage<FavResUpdate>(EventType.CST_SONG_FAV_update, { userFavorites: favorite });
 				this.listeners.forEach((listener) => {
 					if (areResultsPublic(this.constitution) || listener.uid !== favorite.uid) {
 						listener.socket.send(updateMessage);
@@ -111,7 +111,7 @@ export class FavoriteModule extends SubModule<SongData> {
 		this.listeners.add(client);
 
 		this.favorites.forEach((favorite) => {
-			const updateMessage = createMessage<FavResUpdate>(EventType.CST_FAV_update, { userFavorites: favorite });
+			const updateMessage = createMessage<FavResUpdate>(EventType.CST_SONG_FAV_update, { userFavorites: favorite });
 			if (areResultsPublic(this.constitution) || client.uid === favorite.uid) {
 				client.socket.send(updateMessage);
 				telemetry.read();

--- a/src/WebSocket/modules/song.ts
+++ b/src/WebSocket/modules/song.ts
@@ -73,6 +73,9 @@ export class SongModule extends SubModule<Constitution> {
 		if (message.event.startsWith(`CST-${this.prefix}-${this.voteSubmodule.prefix}`)) {
 			return this.voteSubmodule.handleEvent(message, client);
 		}
+		if (message.event.startsWith(`CST-${this.prefix}-${this.favoritesSubmodule.prefix}`)) {
+			return this.favoritesSubmodule.handleEvent(message, client);
+		}
 
 		const eventCallback = this.moduleMap.get(message.event);
 		if (eventCallback === undefined) {

--- a/src/WebSocket/modules/song.ts
+++ b/src/WebSocket/modules/song.ts
@@ -5,8 +5,8 @@ import { Client } from "../../Types/client";
 import { SubModule } from "../module";
 import { telemetry } from "./telemetry";
 import { cleanupString, FS_CONSTITUTIONS_PATH } from "../utility";
-import { VoteData } from "../../Types/vote-data";
 import { GradeVoteModule } from "./vote-modules/grade";
+import { VoteModule } from "./vote-modules/vote";
 
 const SONG_NAME_LENGTH = 100;	// TODO
 const SONG_AUTHOR_LENGTH = 100;
@@ -19,7 +19,7 @@ export class SongModule extends SubModule<Constitution> {
 
 	private listeners: Set<Client> = new Set();
 
-	private voteSubmodule: SubModule<VoteData>;
+	private voteSubmodule: VoteModule;
 
 	constructor(private constitution: Constitution) {
 		super();
@@ -115,7 +115,7 @@ export class SongModule extends SubModule<Constitution> {
 			author: cleanupString(songData.author, SONG_AUTHOR_LENGTH),
 			platform: songData.platform ?? SongPlatform.YOUTUBE,
 			title: cleanupString(songData.title, SONG_NAME_LENGTH),
-			url: songData.url,
+			url: songData.url ?? "https://www.youtube.com/watch?v=MYZ67-Sh7kM",
 			user: client.uid
 		};
 
@@ -134,6 +134,8 @@ export class SongModule extends SubModule<Constitution> {
 		const song = this.songs.get(requestData.songId);
 		if (isNil(song)) return;
 		if (song.user !== client.uid) return;
+
+		this.voteSubmodule.deleteSong(song.id);
 
 		firestore.collection(this.path).doc(song.id.toString()).delete();
 	}

--- a/src/WebSocket/modules/song.ts
+++ b/src/WebSocket/modules/song.ts
@@ -7,6 +7,7 @@ import { telemetry } from "./telemetry";
 import { cleanupString, FS_CONSTITUTIONS_PATH } from "../utility";
 import { GradeVoteModule } from "./vote-modules/grade";
 import { VoteModule } from "./vote-modules/vote";
+import { FavoriteModule } from "./favorite";
 
 const SONG_NAME_LENGTH = 100;	// TODO
 const SONG_AUTHOR_LENGTH = 100;
@@ -20,6 +21,7 @@ export class SongModule extends SubModule<Constitution> {
 	private listeners: Set<Client> = new Set();
 
 	private voteSubmodule: VoteModule;
+	private favoritesSubmodule: FavoriteModule;
 
 	constructor(private constitution: Constitution) {
 		super();
@@ -30,6 +32,7 @@ export class SongModule extends SubModule<Constitution> {
 
 		this.path = `${FS_CONSTITUTIONS_PATH}/${constitution.id}/songs`;
 
+		this.favoritesSubmodule = new FavoriteModule(this.constitution, this.songs);
 		switch (constitution.type) {
 			case ConstitutionType.GRADE:
 			default: {
@@ -88,6 +91,7 @@ export class SongModule extends SubModule<Constitution> {
 	public updateData(constitution: Constitution): void {
 		this.constitution = constitution;
 		this.voteSubmodule.updateData({ constitution: constitution, songs: this.songs });
+		this.favoritesSubmodule.updateData({ constitution: constitution, songs: this.songs });
 	}
 
 	private nextSongId(): number {
@@ -136,6 +140,7 @@ export class SongModule extends SubModule<Constitution> {
 		if (song.user !== client.uid) return;
 
 		this.voteSubmodule.deleteSong(song.id);
+		this.favoritesSubmodule.deleteFavorites(song.id);
 
 		firestore.collection(this.path).doc(song.id.toString()).delete();
 	}

--- a/src/WebSocket/modules/vote-modules/grade.ts
+++ b/src/WebSocket/modules/vote-modules/grade.ts
@@ -1,7 +1,7 @@
 import { canModifyVotes, createMessage, EventType, extractMessageData, GradeReqEdit, GradeReqUnsubscribe, GradeResSummaryUpdate, Message, KGradeSummary, KGradeUserData, GradeResUserDataUpdate, Song } from "chelys";
 import { inRange, isNil, toString } from "lodash";
 import { Client } from "../../../Types/client";
-import { VoteData } from "../../../Types/vote-data";
+import { SongData } from "../../../Types/song-data";
 import { firestore, firestoreTypes } from "../../firebase";
 import { FS_CONSTITUTIONS_PATH } from "../../utility";
 import { telemetry } from "../telemetry";
@@ -16,7 +16,7 @@ export class GradeVoteModule extends VoteModule {
 	private userDatas: Map<string, KGradeUserData> = new Map();
 	private userDataListeners: Map<string, Set<Client>> = new Map();
 
-	constructor(private data: VoteData) {
+	constructor(private data: SongData) {
 		super();
 
 		this.moduleMap.set(EventType.CST_SONG_GRADE_get_summary, this.getSummary);
@@ -86,7 +86,7 @@ export class GradeVoteModule extends VoteModule {
 		return;
 	}
 
-	public updateData(data: VoteData): void {
+	public updateData(data: SongData): void {
 		this.data = data;
 	}
 

--- a/src/WebSocket/modules/vote-modules/grade.ts
+++ b/src/WebSocket/modules/vote-modules/grade.ts
@@ -102,7 +102,6 @@ export class GradeVoteModule extends VoteModule {
 				telemetry.write(false);
 			}
 		}
-		console.log("All done")
 	}
 
 	private async getSummary(_: Message<unknown>, client: Client): Promise<void> {

--- a/src/WebSocket/modules/vote-modules/vote.ts
+++ b/src/WebSocket/modules/vote-modules/vote.ts
@@ -1,6 +1,6 @@
-import { VoteData } from "../../../Types/vote-data";
+import { SongData } from "../../../Types/song-data";
 import { SubModule } from "../../module";
 
-export abstract class VoteModule extends SubModule<VoteData> {
+export abstract class VoteModule extends SubModule<SongData> {
     public abstract deleteSong(songID: number): void;
 }

--- a/src/WebSocket/modules/vote-modules/vote.ts
+++ b/src/WebSocket/modules/vote-modules/vote.ts
@@ -1,0 +1,6 @@
+import { VoteData } from "../../../Types/vote-data";
+import { SubModule } from "../../module";
+
+export abstract class VoteModule extends SubModule<VoteData> {
+    public abstract deleteSong(songID: number): void;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
 		/* Visit https://aka.ms/tsconfig.json to read more about this file */
 		/* Basic Options */
 		// "incremental": true,                         /* Enable incremental compilation */
-		"target": "es5", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+		"target": "es6", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
 		"module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
 		// "lib": [],                                   /* Specify library files to be included in the compilation. */
 		// "allowJs": true,                             /* Allow javascript files to be compiled. */


### PR DESCRIPTION
## Description
Cette PR refactor les favoris et les votes pour les mettres au même niveau. Ceci permet de supprimer toutes les ressources nécessaires lorsqu'un utilisateur décide de supprimer une chanson.

### :tada: Quality of life
La période des vote et la période d'ajout de chansons ont maintenant été fusionnées.

### :bug: Bugfix
* Fix d'un bug si le client envoyait une URL de chanson undefined.

### :hammer_and_wrench: Refactoring
- Le module de vote est maintenant un sous module du module de chansons
- Le module de favoris est maintenant un sous module du module de chansons
- Passage à Chelys 2.8.1

## Checklist

- [x] Titre
- [x] Label
- [x] Catégorie