### PR TITLE
Fix d'un bug de switch case utilisant l'opérateur `||`

### DIFF
--- a/src/WebSocket/modules/invite.ts
+++ b/src/WebSocket/modules/invite.ts
@@ -27,10 +27,15 @@ class InviteModule extends Module {
 				const data = change.doc.data() as Invite;
 				let updateMessage: string;
 				switch (change.type) {
-					case "added" || "modified":
+					case "added":
 						this.invites.set(data.id, data);
 						telemetry.read(false);
 						updateMessage = createMessage<InvResUpdate>(EventType.INVITE_update, { invite: data, status: "added" });
+						break;
+					case "modified":
+						this.invites.set(data.id, data);
+						telemetry.read(false);
+						updateMessage = createMessage<InvResUpdate>(EventType.INVITE_update, { invite: data, status: "modified" });
 						break;
 					case "removed":
 						this.invites.delete(data.id);


### PR DESCRIPTION
## Description
Cette PR fix un bug mineur concernant le traitement des évènements firebase des invitations

### :bug: Bugfix
* L'opérateur || ne peut pas être utilisé dans un switch-case pour regrouper plusieurs valeurs. Il ne fait que regarder la valeur de gauche.

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie