### PR TITLE
Support du champ `languages` d'une chanson

### DIFF
--- a/src/WebSocket/modules/song.ts
+++ b/src/WebSocket/modules/song.ts
@@ -130,7 +130,8 @@ export class SongModule extends SubModule<Constitution> {
 			album: songData.album,
 			altTitles: songData.altTitles,
 			genres: songData.genres,
-			releaseYear: songData.releaseYear
+			releaseYear: songData.releaseYear,
+			languages: songData.languages
 		};
 
 		firestore.collection(this.path).doc(song.id.toString()).create(song);


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :rocket: Nouveauté
* Ajout du support pour le champ optionnel `languages` d'une chanson.

## Dépendance issues/pull request
<!-- * #{Numéro issue } -->
* Équivalent Yatga : https://github.com/TableauBits/Yatga/pull/116

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie