### PR TITLE
Ajout du param ENVIRONMENT pour pouvoir changer l'adresse de connexion en production

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -3,3 +3,6 @@ MATBAY_SERVICE_ACCOUNT_KEY=
 
 # Password for dashboard (optional, defaults to empty string)
 DASHBOARD_PASSWORD=
+
+# Variable to know whether or not the server is running in a production environment or not (optional in development, but must be set to "PRODUCTION", when in production)
+ENVIRONMENT=

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: printf "MATBAY_SERVICE_ACCOUNT_KEY=${{ secrets.MATBAY_SERVICE_ACCOUNT_KEY }}\nDASHBOARD_PASSWORD=${{ secrets.DASHBOARD_PASSWORD }}" >> .env 
+      - run: printf "MATBAY_SERVICE_ACCOUNT_KEY=${{ secrets.MATBAY_SERVICE_ACCOUNT_KEY }}\nDASHBOARD_PASSWORD=${{ secrets.DASHBOARD_PASSWORD }}\nENVIRONMENT=PRODUCTION" >> .env 
       - run: npm install typescript
       - run: npm run build 
       - uses: superfly/flyctl-actions/setup-flyctl@master

--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ dist
 tests/manual-testing/tine/debug
 tests/manual-testing/tine/target
 tests/manual-testing/tine/Cargo.lock
+
+# bun files
+bun.lockb

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,14 +7,17 @@ import { Server } from "ws";
 import { createEndpoints } from "./REST/endpoint-creation";
 import { setupWS } from "./WebSocket/event-handler";
 
+const isProd = process.env["ENVIRONMENT"] === "PRODUCTION";
+
 // create HTTP server
-const port = process.env["PORT"] || 3000;
+const port = parseInt(process.env["PORT"] || "3000");
+const listenIP = isProd ? "0.0.0.0" : "localhost";
 const server = createEndpoints(
 	express()
 		.use(cors())
 		.use(express.json())
 )
-	.listen(port, () => console.log(`server listening on ${port}`));
+	.listen(port, listenIP, () => console.log(`server listening on ${port}`));
 
 // create WS server
 const wsServer = new Server({ server });


### PR DESCRIPTION
## Description
Tentative de hotfix pour régler les problèmes de hosting suite au retrait des adresses IPV4 gratuites de fly.io

### :bug: Bugfix
- le serveur essayera désormais de se connecter à 0.0.0.0 si il détecte qu'il tourne en production

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie