### PR TITLE
Fix de la configuration fly io pour que kalimba soit toujours up et que les lectures n'explosent pas

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -16,5 +16,5 @@ internal_port = 3000
 force_https = true
 auto_stop_machines = true
 auto_start_machines = true
-min_machines_running = 0
+min_machines_running = 1
 processes = ["app"]


### PR DESCRIPTION
## Description
Quelque chose à changé dans le fonctionnement interne de fly.io ou de notre configuration qui fait que kalimba se fait shutdown et reboot par fly.io lors des périodes d'inactivité, mais pour ne pas exploser les requêtes firebase, il vaut mieux que kalimba reste up le plus possible.

Le changement est déjà déployé, mais cette PR sers à faire en sorte que le changement persiste après les futures déploiements des prochaines PRs.

### :bug: Bugfix
- la valeur de `min_machines` est passé à 1 (oui, c'est vraiment tout)

## Checklist

- [x] Titre
- [x] Label
- [x] Catégorie