### PR TITLE
Déploiement via Github release au lieu de la branche release

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,7 +1,7 @@
 name: Fly deploy
 on:
   release:
-    types: 
+    types:
       - published
 
 env:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,8 +1,8 @@
 name: Fly deploy
 on:
-  push:
-    branches:
-      - release
+  release:
+    types: 
+      - published
 
 env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :hammer_and_wrench: Refactoring
* Remplace la condition pour déployer le code sur fly.io. Désormais celui-ci sera déployer lors de la création d'une release Github au lieu d'un merge sur la branche release comme sur Yatga.

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie