### PR TITLE
Ajout du support pour les pays d'une chanson

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@typescript-eslint/eslint-plugin": "^4.23.0",
 				"@typescript-eslint/parser": "^4.23.0",
 				"bufferutil": "^4.0.3",
-				"chelys": "^2.18.1",
+				"chelys": "^2.19.0",
 				"copyfiles": "^2.4.1",
 				"cors": "^2.8.5",
 				"dotenv": "^10.0.0",
@@ -1277,10 +1277,9 @@
 			}
 		},
 		"node_modules/chelys": {
-			"version": "2.18.1",
-			"resolved": "https://registry.npmjs.org/chelys/-/chelys-2.18.1.tgz",
-			"integrity": "sha512-iBR2SvxRm1ktRj9hQ5FYmH6ij09aoqFmn2DG+bUjmNIk0gIrn9/rLIA5/MF1CE38k6o3jGj9a+4BKi0QUxBqTg==",
-			"license": "ISC"
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/chelys/-/chelys-2.19.0.tgz",
+			"integrity": "sha512-6jxOp0gvKz4+uGDTsh9fOFWApyA0fOICaTyffDqRhc3YYiPU2bfWDRA/HVmno/dSIAH7MQKM2h0ZqkKtn6WLRA=="
 		},
 		"node_modules/cliui": {
 			"version": "7.0.4",
@@ -5574,9 +5573,9 @@
 			}
 		},
 		"chelys": {
-			"version": "2.18.1",
-			"resolved": "https://registry.npmjs.org/chelys/-/chelys-2.18.1.tgz",
-			"integrity": "sha512-iBR2SvxRm1ktRj9hQ5FYmH6ij09aoqFmn2DG+bUjmNIk0gIrn9/rLIA5/MF1CE38k6o3jGj9a+4BKi0QUxBqTg=="
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/chelys/-/chelys-2.19.0.tgz",
+			"integrity": "sha512-6jxOp0gvKz4+uGDTsh9fOFWApyA0fOICaTyffDqRhc3YYiPU2bfWDRA/HVmno/dSIAH7MQKM2h0ZqkKtn6WLRA=="
 		},
 		"cliui": {
 			"version": "7.0.4",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"@typescript-eslint/eslint-plugin": "^4.23.0",
 		"@typescript-eslint/parser": "^4.23.0",
 		"bufferutil": "^4.0.3",
-		"chelys": "^2.18.1",
+		"chelys": "^2.19.0",
 		"copyfiles": "^2.4.1",
 		"cors": "^2.8.5",
 		"dotenv": "^10.0.0",

--- a/src/WebSocket/modules/song.ts
+++ b/src/WebSocket/modules/song.ts
@@ -133,6 +133,7 @@ export class SongModule extends SubModule<Constitution> {
 			releaseYear: songData.releaseYear,
 			languages: songData.languages,
 			featuring: songData.featuring,
+			countries: songData.countries,
 		};
 
 		firestore.collection(this.path).doc(song.id.toString()).create(song);


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :rocket: Nouveauté
* Ajout du champ `countries` lors de l'ajout de chanson. Peut être `undefined` ou contient une liste de code ISO3166 alpha-2.

### :hammer_and_wrench: Refactoring
* Passage à Chelys `2.19.0`.

## Dépendance issues/pull request
<!-- * #{Numéro issue } -->

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie